### PR TITLE
Allow "eval $EDITOR" with no arguments.

### DIFF
--- a/autoload/edita/neovim/client.vim
+++ b/autoload/edita/neovim/client.vim
@@ -5,7 +5,7 @@ function! edita#neovim#client#open() abort
   let mode = edita#neovim#util#mode(server)
   let ch = sockconnect(mode, server, { 'rpc': 1 })
   let args = argv()
-  let target = len(args) != 0 ? fnamemodify(args[-1], ':p') : ""
+  let target = len(args) isnot# 0 ? fnamemodify(args[-1], ':p') : ""
   let client = serverstart()
   call rpcrequest(ch, 'nvim_command', printf(
         \ 'call edita#neovim#editor#open("%s", "%s")',

--- a/autoload/edita/neovim/client.vim
+++ b/autoload/edita/neovim/client.vim
@@ -4,7 +4,8 @@ function! edita#neovim#client#open() abort
   let server = $NVIM_LISTEN_ADDRESS
   let mode = edita#neovim#util#mode(server)
   let ch = sockconnect(mode, server, { 'rpc': 1 })
-  let target = fnamemodify(argv()[-1], ':p')
+  let args = argv()
+  let target = len(args) != 0 ? fnamemodify(args[-1], ':p') : ""
   let client = serverstart()
   call rpcrequest(ch, 'nvim_command', printf(
         \ 'call edita#neovim#editor#open("%s", "%s")',

--- a/autoload/edita/neovim/editor.vim
+++ b/autoload/edita/neovim/editor.vim
@@ -10,7 +10,7 @@ function! edita#neovim#editor#open(target, client)
 endfunction
 
 function! s:BufDelete() abort
-  let ch = getbufvar(expand('<afile>'), 'edita', v:null)
+  let ch = getbufvar(str2nr(expand('<abuf>')), 'edita', v:null)
   if ch is# v:null
     return
   endif

--- a/autoload/edita/vim/client.vim
+++ b/autoload/edita/vim/client.vim
@@ -2,7 +2,8 @@ let s:repo = fnamemodify(expand('<sfile>'), ':p:h:h:h:h')
 
 function! edita#vim#client#open() abort
   bwipeout!
-  let target = fnamemodify(argv()[-1], ':p')
+  let args = argv()
+  let target = len(args) != 0 ? fnamemodify(args[-1], ':p') : ""
   call s:send(['call', 'Tapi_edita_open', [target]])
   enew | redraw
   " Disable mappings to prevent accidental edit

--- a/autoload/edita/vim/client.vim
+++ b/autoload/edita/vim/client.vim
@@ -3,7 +3,7 @@ let s:repo = fnamemodify(expand('<sfile>'), ':p:h:h:h:h')
 function! edita#vim#client#open() abort
   bwipeout!
   let args = argv()
-  let target = len(args) != 0 ? fnamemodify(args[-1], ':p') : ""
+  let target = len(args) isnot# 0 ? fnamemodify(args[-1], ':p') : ""
   call s:send(['call', 'Tapi_edita_open', [target]])
   enew | redraw
   " Disable mappings to prevent accidental edit

--- a/autoload/edita/vim/editor.vim
+++ b/autoload/edita/vim/editor.vim
@@ -11,7 +11,7 @@ function! edita#vim#editor#open(target, bufnr)
 endfunction
 
 function! s:BufDelete() abort
-  let bufnr = getbufvar(expand('<afile>'), 'edita', v:null)
+  let bufnr = getbufvar(str2nr(expand('<abuf>')), 'edita', v:null)
   if bufnr is# v:null
     return
   endif


### PR DESCRIPTION
I added edita.vim to Vim and wrote `.bashrc` as following:
```bash
alias vim="eval $EDITOR"
```
And executed `vim` with no arguments, this error is occurred:
```error
Error detected while processing command line..function edita#vim#client#open:
line    2:
E684: list index out of range: -1
E116: Invalid arguments for function fnamemodify(argv()[-1], ':p')
```

Then I fixed `autoload/edita/*/client.vim`, It worked, but new problem was arisen: Client dosen't quit vim when the new buffer was closed. So I patched `autoload/edita/*/editor.vim` to work it.

Now it works very well, please merge this patch.

Note that my environment:
> - Linux 5.11.15 (x86_64)
> - Vim 8.2.2803 (with `+terminal`)
> - Not tested in Neovim